### PR TITLE
Updating debugPayloadApps status check

### DIFF
--- a/samples/plugins/hostsvc/hostsvc-logging/starter-plugin/debugPayloadApp/Services/MessageSender.cs
+++ b/samples/plugins/hostsvc/hostsvc-logging/starter-plugin/debugPayloadApp/Services/MessageSender.cs
@@ -130,11 +130,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}'received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
     }
 
@@ -172,11 +167,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}'received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
     }

--- a/samples/plugins/hostsvc/hostsvc-position/starter-plugin/debugPayloadApp/Services/MessageSender.cs
+++ b/samples/plugins/hostsvc/hostsvc-position/starter-plugin/debugPayloadApp/Services/MessageSender.cs
@@ -138,11 +138,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -176,11 +171,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 

--- a/samples/plugins/hostsvc/hostsvc-sensor/starter-plugin/debugPayloadApp/Services/MessageSender.cs
+++ b/samples/plugins/hostsvc/hostsvc-sensor/starter-plugin/debugPayloadApp/Services/MessageSender.cs
@@ -144,11 +144,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -184,11 +179,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -223,11 +213,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 

--- a/samples/plugins/platform/platform-mts/starter-plugin/debugPayloadApp/Services/MessageSender.cs
+++ b/samples/plugins/platform/platform-mts/starter-plugin/debugPayloadApp/Services/MessageSender.cs
@@ -154,11 +154,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -192,11 +187,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
@@ -253,11 +243,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}'received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
     }
 
@@ -295,11 +280,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}'received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
     }
@@ -351,11 +331,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -391,11 +366,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -430,11 +400,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 

--- a/samples/plugins/platform/vth/starter-plugin/debugPayloadApp/Services/MessageSender.cs
+++ b/samples/plugins/platform/vth/starter-plugin/debugPayloadApp/Services/MessageSender.cs
@@ -154,11 +154,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -192,11 +187,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
@@ -253,11 +243,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}'received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
     }
 
@@ -295,11 +280,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}'received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
     }
@@ -351,11 +331,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -391,11 +366,6 @@ public class MessageSender : BackgroundService {
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
 
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
-
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 
     }
@@ -430,11 +400,6 @@ public class MessageSender : BackgroundService {
         }
 
         if (response == null) throw new TimeoutException($"Failed to hear {nameof(response)} after {MAX_TIMESPAN_TO_WAIT_FOR_MSG}.  Please check that {_hostSvcAppId} is deployed");
-
-        if (response.ResponseHeader.Status != Microsoft.Azure.SpaceFx.MessageFormats.Common.StatusCodes.Successful) {
-            throw new Exception($"'{request.GetType().Name}' failed with status '{response.ResponseHeader.Status}' and message '{response.ResponseHeader.Message}'");
-        }
-
 
         _logger.LogInformation($"'{request.GetType().Name}' request received.  Status: '{response.ResponseHeader.Status}' (TrackingId: '{request.RequestHeader.TrackingId}')");
 


### PR DESCRIPTION
The debug payload apps in the plugin starts are inadvertently expecting a success status on the messages, even though the plugin endpoints the debug payload apps are querying aren't necessarily responsible for setting the status to successful.  This was creating an occasional failure in the app.

This PR removes those checks and just verifies that a response was heard.