### PR TITLE
Fix `numpy` dependecy error in shipdetector-onnx

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,10 +15,10 @@
 			"pull_containers": "datagenerator-planetary-computer:0.11.0-nightly"
 		}
 	},
-	// "hostRequirements": {
-	// 	"cpus": 8,
-	// 	"memory": "8gb"
-	// },
+	"hostRequirements": {
+		"cpus": 8,
+		"memory": "8gb"
+	},
 	"customizations": {
 		"vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,10 +15,10 @@
 			"pull_containers": "datagenerator-planetary-computer:0.11.0-nightly"
 		}
 	},
-	"hostRequirements": {
-		"cpus": 8,
-		"memory": "8gb"
-	},
+	// "hostRequirements": {
+	// 	"cpus": 8,
+	// 	"memory": "8gb"
+	// },
 	"customizations": {
 		"vscode": {
             "extensions": [

--- a/samples/payloadapps/python/shipdetector-onnx/pyproject.toml
+++ b/samples/payloadapps/python/shipdetector-onnx/pyproject.toml
@@ -22,6 +22,7 @@ opencv-python-headless = "^4.8.1.78"
 grpcio-tools = "^1.26.0"
 grpcio = "^1.26.0"
 protobuf = "^3.20.1"
+numpy = "1.24.4"
 
 [tool.poetry.dependencies.microsoftazurespacefx]
 path = ".wheel/microsoftazurespacefx-0.11.0-py3-none-any.whl"


### PR DESCRIPTION
Currently, running the devcontainer for shipdetector-onnx will give this error:
![image](https://github.com/user-attachments/assets/f03e9e50-4b93-4135-88ae-889c9f2437ca)

This is because of the `rasterio` import which is not compatible with the latest version of `numpy`.
Looking at the `poetry.lock` it looks like the expected numpy version is `1.24.4`.

So, I added the exact version requirement in `pyproject.toml`.